### PR TITLE
Retrieve translated custom fields

### DIFF
--- a/src/Subscriber/NavigationLoadedSubscriber.php
+++ b/src/Subscriber/NavigationLoadedSubscriber.php
@@ -38,7 +38,7 @@ class NavigationLoadedSubscriber implements EventSubscriberInterface
         /** @var TreeItem $treeItem */
         foreach ($tree as $treeItem) {
             $category = $treeItem->getCategory();
-            $customFields = $category->getCustomFields() ?? [];
+            $customFields = $category->getTranslated()['customFields'] ?? [];
             if (array_key_exists('rl_cl_isCategoryLink', $customFields) && $customFields['rl_cl_isCategoryLink'] === '1') {
                 $categoryId = $customFields['rl_cl_categoryId'];
                 $url = $this->handler->generate('frontend.navigation.page', ['navigationId' => $categoryId]);


### PR DESCRIPTION
Currently when you set a category link in English in the administration the link will not work for Dutch, because customFields is empty. This commit retrieves the translated customFields so that the link will work.

<img width="642" alt="Screenshot 2021-03-22 at 13 49 34" src="https://user-images.githubusercontent.com/26538915/111992618-e8214280-8b15-11eb-91a0-6fb6143b7ec1.png">

